### PR TITLE
Lack of returning animation transition delegate result if implemented

### DIFF
--- a/UINavigationControllerWithCompletionBlock/UINavigationControllerWithCompletionBlock/UINavigationControllerWithCompletionBlock/UINavigationController+CompletionBlock.m
+++ b/UINavigationControllerWithCompletionBlock/UINavigationControllerWithCompletionBlock/UINavigationControllerWithCompletionBlock/UINavigationController+CompletionBlock.m
@@ -260,10 +260,10 @@ typedef NS_ENUM(NSUInteger, UINavigationControllerState) {
 {
     //Call nextDelegate
     if ([[self nextDelegate] respondsToSelector:@selector(navigationController:animationControllerForOperation:fromViewController:toViewController:)]) {
-        [[self nextDelegate] navigationController:navigationController
-                  animationControllerForOperation:operation
-                               fromViewController:fromVC
-                                 toViewController:toVC];
+        return [[self nextDelegate] navigationController:navigationController
+                         animationControllerForOperation:operation
+                                      fromViewController:fromVC
+                                        toViewController:toVC];
     }
     
     return nil;


### PR DESCRIPTION
Hi, thanks for the hard work!

I faced an issue with custom transition animations after delegate swizzling enabled - my delegate implementation was called but its result just ignored.

Cheers,
g4bor