### PR TITLE
Update void parameter for prototype block

### DIFF
--- a/Pod/Classes/JMONavigationAction.h
+++ b/Pod/Classes/JMONavigationAction.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-typedef void (^JMONavCompletionBlock)();
+typedef void (^JMONavCompletionBlock)(void);
 
 typedef NS_ENUM(NSUInteger, JMONavigationActionType) {
     JMONavigationActionTypePush,


### PR DESCRIPTION
iOS 11 mark as warning when there is empty list of parameter type. So, instead of this, it should be written void.